### PR TITLE
Catch and propagate cancellation when parsing/ processing files

### DIFF
--- a/Canopy.Cli.Shared/StudyProcessing/ChannelData/WriteChannelDataAsBinary.cs
+++ b/Canopy.Cli.Shared/StudyProcessing/ChannelData/WriteChannelDataAsBinary.cs
@@ -60,6 +60,11 @@ namespace Canopy.Cli.Shared.StudyProcessing.ChannelData
                                 await writer.DeleteProcessedFile(root, domain.File);
                             }
                         }
+                        catch (OperationCanceledException)
+                        {
+                            // Propagate cancellation so it isn't reported as a processing error.
+                            throw;
+                        }
                         catch (Exception t)
                         {
                             writer.ReportError(

--- a/Canopy.Cli.Shared/StudyProcessing/ChannelData/WriteChannelDataAsCsv.cs
+++ b/Canopy.Cli.Shared/StudyProcessing/ChannelData/WriteChannelDataAsCsv.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 namespace Canopy.Cli.Shared.StudyProcessing.ChannelData
 {
     using System;
@@ -74,6 +74,11 @@ namespace Canopy.Cli.Shared.StudyProcessing.ChannelData
                                         resolvedData.Enqueue(
                                             new ResolvedCsvColumn(column.File, column.Metadata.ChannelName, values));
                                     }
+                                }
+                                catch (OperationCanceledException)
+                                {
+                                    // Propagate cancellation so it isn't reported as a parsing error.
+                                    throw;
                                 }
                                 catch (Exception t)
                                 {
@@ -152,6 +157,11 @@ namespace Canopy.Cli.Shared.StudyProcessing.ChannelData
                                     kvp.Name,
                                     kvp.Data));
                             }
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            // Propagate cancellation so it isn't reported as a parsing error.
+                            throw;
                         }
                         catch (Exception t)
                         {


### PR DESCRIPTION
Processing errors are different from cancellation exceptions and therefore the latter should be treated differently. The calling code deals with cancellation exceptions. 