### PR TITLE
Migrate Parquet.Net from 5.4.0 to 6.0.0

### DIFF
--- a/Canopy.Cli.Shared.Tests/Canopy.Cli.Shared.Tests.csproj
+++ b/Canopy.Cli.Shared.Tests/Canopy.Cli.Shared.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
     <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-    <PackageReference Include="Parquet.Net" Version="5.4.0" />
+    <PackageReference Include="Parquet.Net" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Canopy.Cli.Shared.Tests/Canopy.Cli.Shared.Tests.csproj
+++ b/Canopy.Cli.Shared.Tests/Canopy.Cli.Shared.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
     <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-    <PackageReference Include="Parquet.Net" Version="6.0.0" />
+    <PackageReference Include="Parquet.Net" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Canopy.Cli.Shared.Tests/StudyProcessing/ChannelData/TelemetryChannelSerializerTests.cs
+++ b/Canopy.Cli.Shared.Tests/StudyProcessing/ChannelData/TelemetryChannelSerializerTests.cs
@@ -1,7 +1,6 @@
 #nullable enable
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Parquet;
-using Parquet.Data;
 using Parquet.Schema;
 using System;
 using System.Collections.Generic;
@@ -37,7 +36,7 @@ namespace Canopy.Cli.Shared.StudyProcessing.ChannelData
 
             var schema = new ParquetSchema(fields);
 
-            using (var parquetWriter = await ParquetWriter.CreateAsync(schema, memoryStream))
+            await using (var parquetWriter = await ParquetWriter.CreateAsync(schema, memoryStream))
             using (var groupWriter = parquetWriter.CreateRowGroup())
             {
                 foreach (var kv in columns)
@@ -48,15 +47,14 @@ namespace Canopy.Cli.Shared.StudyProcessing.ChannelData
                     switch (sample)
                     {
                         case float:
-                            await groupWriter.WriteColumnAsync(new DataColumn(field, kv.Value.Cast<float>().ToArray()));
+                            await groupWriter.WriteAsync<float>(field, kv.Value.Cast<float>().ToArray().AsMemory(), null, null, default);
                             break;
                         case double:
-                            await groupWriter.WriteColumnAsync(new DataColumn(field, kv.Value.Cast<double>().ToArray()));
-                            break;                     
+                            await groupWriter.WriteAsync<double>(field, kv.Value.Cast<double>().ToArray().AsMemory(), null, null, default);
+                            break;
                         default:
-                            // Fallback: try to convert numeric-like values to float
                             var fallback = kv.Value.Select(v => Convert.ToSingle(v)).ToArray();
-                            await groupWriter.WriteColumnAsync(new DataColumn(field, fallback));
+                            await groupWriter.WriteAsync<float>(field, fallback.AsMemory(), null, null, default);
                             break;
                     }
                 }

--- a/Canopy.Cli.Shared/Canopy.Cli.Shared.csproj
+++ b/Canopy.Cli.Shared/Canopy.Cli.Shared.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Parquet.Net" Version="6.0.0" />
+    <PackageReference Include="Parquet.Net" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/Canopy.Cli.Shared/Canopy.Cli.Shared.csproj
+++ b/Canopy.Cli.Shared/Canopy.Cli.Shared.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Parquet.Net" Version="5.4.0" />
+    <PackageReference Include="Parquet.Net" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Canopy.Cli.Shared/StudyProcessing/ChannelData/ChannelValueConverter.cs
+++ b/Canopy.Cli.Shared/StudyProcessing/ChannelData/ChannelValueConverter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Parquet.Data;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -8,6 +9,25 @@ namespace Canopy.Cli.Shared.StudyProcessing.ChannelData
     {
         T Convert(object rawValue);
         byte[] Serialize(IEnumerable<T> values);
+
+        void AddConvertedValues(RawColumnData rawData, List<T> targetList)
+        {
+            switch (rawData)
+            {
+                case RawColumnData<float> fd:
+                    foreach (var v in fd.Values) targetList.Add(Convert(v));
+                    break;
+                case RawColumnData<double> dd:
+                    foreach (var v in dd.Values) targetList.Add(Convert(v));
+                    break;
+                case RawColumnData<int> id:
+                    foreach (var v in id.Values) targetList.Add(Convert(v));
+                    break;
+                case RawColumnData<long> ld:
+                    foreach (var v in ld.Values) targetList.Add(Convert(v));
+                    break;
+            }
+        }
     }
 
     public sealed class FloatChannelValueConverter : IChannelValueConverter<float>
@@ -45,6 +65,46 @@ namespace Canopy.Cli.Shared.StudyProcessing.ChannelData
         {
             var list = values.ToArray();
             var bytes = new byte[list.Length * sizeof(double)];
+            Buffer.BlockCopy(list, 0, bytes, 0, bytes.Length);
+            return bytes;
+        }
+    }
+
+    public sealed class IntChannelValueConverter : IChannelValueConverter<int>
+    {
+        public int Convert(object rawValue) => rawValue switch
+        {
+            int n => n,
+            long l => (int)l,
+            float f => (int)f,
+            double d => (int)d,
+            _ => int.MinValue
+        };
+
+        public byte[] Serialize(IEnumerable<int> values)
+        {
+            var list = values.ToArray();
+            var bytes = new byte[list.Length * sizeof(int)];
+            Buffer.BlockCopy(list, 0, bytes, 0, bytes.Length);
+            return bytes;
+        }
+    }
+
+    public sealed class LongChannelValueConverter : IChannelValueConverter<long>
+    {
+        public long Convert(object rawValue) => rawValue switch
+        {
+            long l => l,
+            int n => (long)n,
+            float f => (long)f,
+            double d => (long)d,
+            _ => long.MinValue
+        };
+
+        public byte[] Serialize(IEnumerable<long> values)
+        {
+            var list = values.ToArray();
+            var bytes = new byte[list.Length * sizeof(long)];
             Buffer.BlockCopy(list, 0, bytes, 0, bytes.Length);
             return bytes;
         }

--- a/Canopy.Cli.Shared/StudyProcessing/ChannelData/TelemetryChannelSerializer.cs
+++ b/Canopy.Cli.Shared/StudyProcessing/ChannelData/TelemetryChannelSerializer.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using Parquet;
-using Parquet.Data;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -64,7 +63,7 @@ namespace Canopy.Cli.Shared.StudyProcessing.ChannelData
             ArgumentNullException.ThrowIfNull(parquetStream);
             ArgumentNullException.ThrowIfNull(converter);
 
-            using var parquetReader = await ParquetReader.CreateAsync(parquetStream, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await using var parquetReader = await ParquetReader.CreateAsync(parquetStream, cancellationToken: cancellationToken).ConfigureAwait(false);
             var channelNamesSet = channelNames != null && channelNames.Count > 0
             ? new HashSet<string>(channelNames)
             : null;
@@ -80,28 +79,10 @@ namespace Canopy.Cli.Shared.StudyProcessing.ChannelData
                 var channelValues = new List<T>((int)(parquetReader.Metadata?.NumRows ?? 0));
                 foreach (var rg in parquetReader.RowGroups)
                 {
-                    var partialColumnData = await rg.ReadColumnAsync(field, cancellationToken);
-                    ConvertAndAddValues(partialColumnData, converter, channelValues);
+                    using var rawData = await rg.ReadRawColumnDataBaseAsync(field, cancellationToken).ConfigureAwait(false);
+                    converter.AddConvertedValues(rawData, channelValues);
                 }
                 yield return (field.Name, channelValues.ToArray());
-            }
-        }
-
-        /// <summary>
-        /// Converts values from a Parquet <see cref="Parquet.Data.DataColumn"/> using the provided converter
-        /// and appends the converted values to <paramref name="targetList"/>.
-        /// </summary>
-        /// <typeparam name="T">Type of the converted values.</typeparam>
-        /// <param name="columnData">The source column data from a Parquet row group.</param>
-        /// <param name="converter">Converter used to transform raw values to <typeparamref name="T"/>.</param>
-        /// <param name="targetList">List to append converted values to.</param>
-        private static void ConvertAndAddValues<T>(DataColumn columnData, IChannelValueConverter<T> converter, List<T> targetList)
-        {
-            var data = columnData.Data;
-
-            for (int j = 0; j < data.Length; j++)
-            {
-                targetList.Add(converter.Convert(data.GetValue(j)));
             }
         }
     }


### PR DESCRIPTION
 The v6 API removes `DataColumn`.

  - Upgrade Parquet.Net package reference to 6.0.0 in both projects
  - Add` IChannelValueConverter<T>.AddConvertedValues` default interface method, which uses `ReadRawColumnDataBaseAsync` (the v6 API for callers that don't know the column type at compile time) and delegates type dispatch to the converter via pattern matching on `RawColumnData<T>`
  - Simplify `TelemetryChannelSerializer `inner loop to read raw column data and delegate to the converter, removing all Parquet type knowledge from the serialiser
  - Add `IntChannelValueConverter `and `LongChannelValueConverter `to complete coverage of the four numeric column types; unrecognised types return `int.MinValue/long.MinValue`
  - Update test helper to use `WriteAsync<T>` with `Memory<T>` buffers and `await using` for `ParquetWriter`, which is now `IAsyncDisposable`